### PR TITLE
fix font color in DarkMode #2

### DIFF
--- a/IP/IP.py
+++ b/IP/IP.py
@@ -579,7 +579,7 @@ class Text():
         self.font_name = _DEFAULT_FONT
         self.fontsize = 20
         self.center_point = {"x":x, "y":y}
-        self.text = CANVAS.create_text(x, y, text=text, font=(self.font,self.fontsize))
+        self.text = CANVAS.create_text(x, y, text=text, font=(self.font,self.fontsize), fill="black")
         self.rotate_point = {"x":0, "y":0}
         
     def font(self, fontName, fontSize):

--- a/IP/__init__.py
+++ b/IP/__init__.py
@@ -2,4 +2,4 @@ from IP.IP import *
 from IP.mouse import *
 from IP.keyboard import *
 
-__version__ = '1.4.8'
+__version__ = '1.4.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "IP"
-version = '1.4.8'
+version = '1.4.9'
 authors = [  { name="Nao Yamanouchi" },]
 description = "CIT Introduction Programming class lib"
 license = {text = "3-Clause BSD License"}


### PR DESCRIPTION
### Why
PCがダークモードの際にフォントカラーが標準で白になってしまい、一見表示されていないように見える状況の解決

### What
Textを生成する部分で明示的にフォントカラーを黒に指定する