### PR TITLE
Delete Image Class method: scale #3

### DIFF
--- a/IP/IP.py
+++ b/IP/IP.py
@@ -614,15 +614,6 @@ class Image():
         self.image_file = tkinter.PhotoImage(file=self.file_path)
         self.image = None
         self.anchor = "center"
-                
-    def scale(self, ratio):
-        if ratio == 1 or ratio == 0:
-            return
-        elif ratio >= 1:
-            self.image_file = self.image_file.zoom(int(ratio),int(ratio))
-        else :
-            ratio = int(1/ratio) if type(ratio)==float else ratio
-            self.image_file = self.image_file.subsample(ratio,ratio)
             
     def changeAnchor(self):
         self.anchor = "nw" if self.anchor=="center" else "center"


### PR DESCRIPTION
### Why
#3 ImageクラスのScale関数を削除する
細かい調整ができないため削除し、画像の調節は各自別ソフトウェアでやってもらう形式に変更する

### What
ImageクラスのScale関数を削除