### PR TITLE
Pre release

### DIFF
--- a/IP/IP.py
+++ b/IP/IP.py
@@ -101,6 +101,8 @@ if _OS == "Darwin":
     _DEFAULT_FONT = "Helvetica"
 elif _OS == "Windows":
     _DEFAULT_FONT = "Segoe UI"
+elif _OS == "Linux":
+    _DEFAULT_FONT = "Noto Serif CJK JP"
 
 def _checkColor(arg):
     if arg in _COLOR or _COLOR_CORD.fullmatch(arg):
@@ -593,6 +595,8 @@ class Text():
         
     def font(self, fontName, fontSize):
         fontName = self.font_name if fontName=="" else fontName
+        if _OS == "Linux":
+            fontName = "Noto Serif CJK JP"
         if fontName not in _FONTS:
             if not _IS_ALL_TRACE : _TraceBack()
             raise FontError(f"{fontName}は使用可能なフォントではありません")

--- a/IP/IP.py
+++ b/IP/IP.py
@@ -1,5 +1,5 @@
 ###
-# プログラミング基礎 v1.5.1
+# プログラミング基礎 v1.5.2
 ###
 from collections.abc import Callable, Iterable, Mapping
 import tkinter

--- a/README.md
+++ b/README.md
@@ -9,17 +9,22 @@ tkinterのWrapperで、[Processing](https://processing.org/)ライクに動作�
 - MacOS
   - Windowsでも使用可能ですが、音楽を再生する機能のみ使用不可です
     - 今後のバージョンでは対応しなくなる可能性があります
-  - Linux系に関しては対応予定ではありません
-    - これは本学科の推奨PCがMacであることに由来します
+  - Linux環境も一応ですが対応しています
+    - Docker環境の用意があります -> [準備中]
+    - 音楽再生はmpvコマンドによって実装しています
 - Python3.10.5 <
   - 動作確認済み >=3.12.2
   - MacのSystem DefaultのPython環境にはライブラリを入れることができないため注意してください
 - Pythonの標準ライブラリのみで動作
   - tkinter 8.6以上が必須
   - brew + pyenv環境の場合、対応したpython-tkが必要です
+- 音楽再生用コマンド
+  - MacOS: afplay
+  - Linux: mpv
 
 ### 開発・動作確認環境
 - MacOS Ventura以降
+- Docker環境 -> [準備中]
 - Python
   - brew + pyenv
   - 3.10.5 <

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "IP"
-version = '1.5.1'
+version = '1.5.2'
 authors = [  { name="Nao Yamanouchi" },]
 description = "CIT Introduction Programming class lib"
 license = {text = "3-Clause BSD License"}


### PR DESCRIPTION
### add
- Docker環境の整備に伴って音楽再生コマンドの追加
  - Linux環境では mpvを、Macではafplayを使用 
- 文字表示
  - デフォルトフォントが異なるため、暫定的にLinuxではNoto Serif CJK JPが強制的に使用されるように変更
  - Docker環境では使用可能になるように整備済み 