### PR TITLE
Release: v1.5.4

### DIFF
--- a/IP/IP.py
+++ b/IP/IP.py
@@ -1,5 +1,5 @@
 ###
-# プログラミング基礎 v1.5.3
+# プログラミング基礎 v1.5.4
 ###
 from collections.abc import Callable, Iterable, Mapping
 import tkinter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "IP"
-version = '1.5.3'
+version = '1.5.4'
 authors = [  { name="Nao Yamanouchi" },]
 description = "CIT Introduction Programming class lib"
 license = {text = "3-Clause BSD License"}


### PR DESCRIPTION
Textクラスで、描画されたテキストが@animatioinデコレータで再描画する際に消えない #33 を解消
原因は描画用のテキストを生成する際に、tagsをつけておらず@animationデコレータで削除対象としているonCanvasタグが付与されていなかったこと